### PR TITLE
telephony: Drop OutgoingSmsMessageId

### DIFF
--- a/src/java/com/android/internal/telephony/RIL.java
+++ b/src/java/com/android/internal/telephony/RIL.java
@@ -1709,8 +1709,7 @@ public class RIL extends BaseCommands implements CommandsInterface {
                             (android.hardware.radio.V1_6.IRadio) radioProxy;
                     radioProxy16.sendSms_1_6(rr.mSerial, msg);
                     mMetrics.writeRilSendSms(mPhoneId, rr.mSerial, SmsSession.Event.Tech.SMS_GSM,
-                            SmsSession.Event.Format.SMS_FORMAT_3GPP,
-                            getOutgoingSmsMessageId(result));
+                            SmsSession.Event.Format.SMS_FORMAT_3GPP);
                 } catch (RemoteException | RuntimeException e) {
                     handleRadioProxyExceptionForRR(rr, "sendSMS", e);
                 }
@@ -1718,8 +1717,7 @@ public class RIL extends BaseCommands implements CommandsInterface {
                 try {
                     radioProxy.sendSms(rr.mSerial, msg);
                     mMetrics.writeRilSendSms(mPhoneId, rr.mSerial, SmsSession.Event.Tech.SMS_GSM,
-                            SmsSession.Event.Format.SMS_FORMAT_3GPP,
-                            getOutgoingSmsMessageId(result));
+                            SmsSession.Event.Format.SMS_FORMAT_3GPP);
                 } catch (RemoteException | RuntimeException e) {
                     handleRadioProxyExceptionForRR(rr, "sendSMS", e);
                 }
@@ -1762,8 +1760,7 @@ public class RIL extends BaseCommands implements CommandsInterface {
                             (android.hardware.radio.V1_6.IRadio) radioProxy;
                     radioProxy16.sendSmsExpectMore_1_6(rr.mSerial, msg);
                     mMetrics.writeRilSendSms(mPhoneId, rr.mSerial, SmsSession.Event.Tech.SMS_GSM,
-                            SmsSession.Event.Format.SMS_FORMAT_3GPP,
-                            getOutgoingSmsMessageId(result));
+                            SmsSession.Event.Format.SMS_FORMAT_3GPP);
                 } catch (RemoteException | RuntimeException e) {
                     handleRadioProxyExceptionForRR(rr, "sendSMSExpectMore", e);
                 }
@@ -1771,8 +1768,7 @@ public class RIL extends BaseCommands implements CommandsInterface {
                 try {
                     radioProxy.sendSMSExpectMore(rr.mSerial, msg);
                     mMetrics.writeRilSendSms(mPhoneId, rr.mSerial, SmsSession.Event.Tech.SMS_GSM,
-                            SmsSession.Event.Format.SMS_FORMAT_3GPP,
-                            getOutgoingSmsMessageId(result));
+                            SmsSession.Event.Format.SMS_FORMAT_3GPP);
                 } catch (RemoteException | RuntimeException e) {
                     handleRadioProxyExceptionForRR(rr, "sendSMSExpectMore", e);
                 }
@@ -3846,8 +3842,7 @@ public class RIL extends BaseCommands implements CommandsInterface {
                 try {
                     radioProxy16.sendCdmaSmsExpectMore_1_6(rr.mSerial, msg);
                     mMetrics.writeRilSendSms(mPhoneId, rr.mSerial, SmsSession.Event.Tech.SMS_CDMA,
-                            SmsSession.Event.Format.SMS_FORMAT_3GPP2,
-                            getOutgoingSmsMessageId(result));
+                            SmsSession.Event.Format.SMS_FORMAT_3GPP2);
                 } catch (RemoteException | RuntimeException e) {
                     handleRadioProxyExceptionForRR(rr, "sendCdmaSMSExpectMore", e);
                 }
@@ -3857,8 +3852,7 @@ public class RIL extends BaseCommands implements CommandsInterface {
                 try {
                     radioProxy15.sendCdmaSmsExpectMore(rr.mSerial, msg);
                     mMetrics.writeRilSendSms(mPhoneId, rr.mSerial, SmsSession.Event.Tech.SMS_CDMA,
-                            SmsSession.Event.Format.SMS_FORMAT_3GPP2,
-                            getOutgoingSmsMessageId(result));
+                            SmsSession.Event.Format.SMS_FORMAT_3GPP2);
                 } catch (RemoteException | RuntimeException e) {
                     handleRadioProxyExceptionForRR(rr, "sendCdmaSMSExpectMore", e);
                 }
@@ -3886,8 +3880,7 @@ public class RIL extends BaseCommands implements CommandsInterface {
                             (android.hardware.radio.V1_6.IRadio) radioProxy;
                     radioProxy16.sendCdmaSms_1_6(rr.mSerial, msg);
                     mMetrics.writeRilSendSms(mPhoneId, rr.mSerial, SmsSession.Event.Tech.SMS_CDMA,
-                            SmsSession.Event.Format.SMS_FORMAT_3GPP2,
-                            getOutgoingSmsMessageId(result));
+                            SmsSession.Event.Format.SMS_FORMAT_3GPP2);
                 } catch (RemoteException | RuntimeException e) {
                     handleRadioProxyExceptionForRR(rr, "sendCdmaSms", e);
                 }
@@ -3895,8 +3888,7 @@ public class RIL extends BaseCommands implements CommandsInterface {
                 try {
                     radioProxy.sendCdmaSms(rr.mSerial, msg);
                     mMetrics.writeRilSendSms(mPhoneId, rr.mSerial, SmsSession.Event.Tech.SMS_CDMA,
-                            SmsSession.Event.Format.SMS_FORMAT_3GPP2,
-                            getOutgoingSmsMessageId(result));
+                            SmsSession.Event.Format.SMS_FORMAT_3GPP2);
                 } catch (RemoteException | RuntimeException e) {
                     handleRadioProxyExceptionForRR(rr, "sendCdmaSms", e);
                 }
@@ -4428,7 +4420,7 @@ public class RIL extends BaseCommands implements CommandsInterface {
             try {
                 radioProxy.sendImsSms(rr.mSerial, msg);
                 mMetrics.writeRilSendSms(mPhoneId, rr.mSerial, SmsSession.Event.Tech.SMS_IMS,
-                        SmsSession.Event.Format.SMS_FORMAT_3GPP, getOutgoingSmsMessageId(result));
+                        SmsSession.Event.Format.SMS_FORMAT_3GPP);
             } catch (RemoteException | RuntimeException e) {
                 handleRadioProxyExceptionForRR(rr, "sendImsGsmSms", e);
             }
@@ -4457,7 +4449,7 @@ public class RIL extends BaseCommands implements CommandsInterface {
             try {
                 radioProxy.sendImsSms(rr.mSerial, msg);
                 mMetrics.writeRilSendSms(mPhoneId, rr.mSerial, SmsSession.Event.Tech.SMS_IMS,
-                        SmsSession.Event.Format.SMS_FORMAT_3GPP2, getOutgoingSmsMessageId(result));
+                        SmsSession.Event.Format.SMS_FORMAT_3GPP2);
             } catch (RemoteException | RuntimeException e) {
                 handleRadioProxyExceptionForRR(rr, "sendImsCdmaSms", e);
             }

--- a/src/java/com/android/internal/telephony/metrics/TelephonyMetrics.java
+++ b/src/java/com/android/internal/telephony/metrics/TelephonyMetrics.java
@@ -2297,15 +2297,13 @@ public class TelephonyMetrics {
      *         {@link SmsMessage#FORMAT_3GPP2}.
      * @param messageId Unique id for this message.
      */
-    public synchronized void writeRilSendSms(int phoneId, int rilSerial, int tech, int format,
-            long messageId) {
+    public synchronized void writeRilSendSms(int phoneId, int rilSerial, int tech, int format) {
         InProgressSmsSession smsSession = startNewSmsSessionIfNeeded(phoneId);
 
         smsSession.addEvent(new SmsSessionEventBuilder(SmsSession.Event.Type.SMS_SEND)
                 .setTech(tech)
                 .setRilRequestId(rilSerial)
                 .setFormat(format)
-                .setMessageId(messageId)
         );
 
         smsSession.increaseExpectedResponse();


### PR DESCRIPTION
* Crashing ims while sending sms over 4G network on some mediatek devices
* Partially revert 6bc58d880b18226aeeca0739f30515d8adcbeed5

Change-Id: I494e68a16a6aef80544e562dd6ba8eb9f3d0eb86
Signed-off-by: SamarV-121 <samarvispute121@pm.me>
Signed-off-by: Sarthak Roy <sarthakroy2002@gmail.com>